### PR TITLE
:zap: [FIX] json_encode TypeError

### DIFF
--- a/jeedomdaemon/aio_connector.py
+++ b/jeedomdaemon/aio_connector.py
@@ -105,6 +105,8 @@ class Publisher():
                             self._logger.debug("first time error during send: %s", e)
                             last_send_on_error = True
                         await self.__merge_dict(self.__changes,changes)
+                    except TypeError as e:
+                        self._logger.error("error during send: %s. No new try to send!", e)
                     else:
                         last_send_on_error = False
                 await asyncio.sleep(self._cycle)


### PR DESCRIPTION
Exception TypeError: "Object of type bytes is not JSON serializable" while trying to send a wrong payload.
This error crashes the `__send_task` Task and no new payload will be sent. It is better to catch this Exception and to ignore the unserializable payload.

Up to you to change the error text.
