### PR TITLE
aio_connector.Publisher.__merge_dict error

### DIFF
--- a/jeedomdaemon/aio_connector.py
+++ b/jeedomdaemon/aio_connector.py
@@ -151,5 +151,5 @@ class Publisher():
             val1 = dic1.get(key) # returns None if v1 has no value for this key
             if isinstance(val1, Mapping) and isinstance(val2, Mapping):
                 await self.__merge_dict(val1, val2)
-            elif not bool(val1) or bool(val2) :
+            else:
                 dic1[key] = val2

--- a/jeedomdaemon/base_daemon.py
+++ b/jeedomdaemon/base_daemon.py
@@ -164,7 +164,7 @@ class BaseDaemon:
                 self._logger.warning('Message received on socket but no callback defined')
 
         except Exception as e: # pylint: disable=broad-exception-caught
-            self._logger.error('Send command to demon error: %s', e)
+            self._logger.error('Send command to daemon error: %s', e)
 
     async def send_to_jeedom(self, payload):
         """


### PR DESCRIPTION
In the function `__merge_dict`, that I simulated without asyncio, I can reproduce the exact same bug: if the value of an element in the first dict is in the second dict and has the value 0 in the second dict then dict1 is not actualized.

Test case:
```python
>>> from collections.abc import Mapping
>>> def merge_dict(dic1: dict, dic2: dict):
...     for key,val2 in dic2.items():
...         val1 = dic1.get(key)
...         if isinstance(val1, Mapping) and isinstance(val2, Mapping):
...             merge_dict(val1, val2)
...         elif not bool(val1) or bool(val2):
...             dic1[key] = val2
...
>>> d1 = {'val::51': 51, 'val::5': 5}
>>> d2 = {'val::5': 7}
>>> d1
{'val::51': 51, 'val::5': 5}
>>> d2
{'val::5': 7}
>>> merge_dict(d1, d2) # 1st merge called to show that it is working
>>> d1
{'val::51': 51, 'val::5': 7}
>>> d2
{'val::5': 7}
>>> d1 = {'val::51': 51, 'val::5': 5}
>>> d2 = {'val::5': 0} # d2 with 0 as value
>>> d1
{'val::51': 51, 'val::5': 5}
>>> d2
{'val::5': 0}
>>> merge_dict(d1, d2) # merge called
>>> d1 # d1 is not modified !!!!
{'val::51': 51, 'val::5': 5}
>>> d2
{'val::5': 0}
```

With this correction, the behaviour is like the expectation.

What is the purpose of this test ?
```
elif not bool(val1) or bool(val2):
```